### PR TITLE
폰트 swap옵션 삭제, font-family 설정

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,6 +1,8 @@
 * {
-  font-family: "pretendard";
   box-sizing: border-box;
+  font-family: Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto, "Helvetica Neue",
+    "Segoe UI", "Apple SD Gothic Neo", "Noto Sans KR", "Malgun Gothic", "Apple Color Emoji",
+    "Segoe UI Emoji", "Segoe UI Symbol", sans-serif;
 }
 
 body {
@@ -19,7 +21,7 @@ button {
   src: url("/font/Pretendard-Regular.subset.woff2") format("woff2"),
     url("/font/Pretendard-Regular.subset.woff") format("woff");
   font-weight: 400;
-  font-display: swap;
+  font-display: auto;
 }
 
 @font-face {
@@ -27,7 +29,7 @@ button {
   src: url("/font/Pretendard-Medium.subset.woff2") format("woff2"),
     url("/font/Pretendard-Medium.subset.woff") format("woff");
   font-weight: 500;
-  font-display: swap;
+  font-display: auto;
 }
 
 @font-face {
@@ -35,5 +37,5 @@ button {
   src: url("/font/Pretendard-Bold.subset.woff2") format("woff2"),
     url("/font/Pretendard-Bold.subset.woff") format("woff");
   font-weight: 700;
-  font-display: swap;
+  font-display: auto;
 }


### PR DESCRIPTION
## 수정
* font-display:swap으로 설정하여 페이지 초기 진입 시 폰트 로딩되는 동안 궁서체보이는 이슈
  * default 값으로 변경
  * font-family 설정 