### PR TITLE
가게 상세 메뉴 섹션 추가

### DIFF
--- a/pages/customer/store/[id]/index.tsx
+++ b/pages/customer/store/[id]/index.tsx
@@ -2,6 +2,7 @@ import React from "react";
 
 import Layout from "customer/components/common/layout";
 import Subs from "customer/components/store/Subs";
+import Menus from "customer/components/store/Menus";
 
 const Store = () => {
   const storeName = "정갈한솥";
@@ -10,6 +11,7 @@ const Store = () => {
     <>
       <Layout title="가게이름">
         <div>Store</div>
+        <Menus />
         <Subs storeName={storeName} />
       </Layout>
     </>

--- a/public/icons/ArrowDown.svg
+++ b/public/icons/ArrowDown.svg
@@ -1,0 +1,3 @@
+<svg width="current" height="current" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M11.0832 5.25L6.99984 9.33333L2.9165 5.25" stroke="current" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/icons/ArrowUp.svg
+++ b/public/icons/ArrowUp.svg
@@ -1,3 +1,3 @@
 <svg width="current" height="current" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M16 10L12 14L8 10" stroke="current" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M5 16L12 9L19 16" stroke="current" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/src/customer/components/Menu.tsx
+++ b/src/customer/components/Menu.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import Image from "next/image";
+import { css } from "@emotion/react";
+
+import { Colors, Texts } from "styles/common";
+
+type MenuProps = {
+  imgSrc: string;
+  name: string;
+  price: number;
+  isBottom: boolean;
+};
+
+const menuImage = (isBottom: boolean) => css`
+  margin-bottom: ${isBottom ? "0.5rem" : "0.25rem"};
+  border-radius: 0.25rem;
+`;
+
+const menuName = css`
+  ${Texts.B3_15_M1}
+`;
+
+const menuPrice = css`
+  ${Texts.B2_14_M}
+  color: ${Colors.neutral70};
+`;
+
+const Menu = (props: MenuProps) => {
+  return (
+    <>
+      <div>
+        <Image
+          css={menuImage(props.isBottom)}
+          src={props.imgSrc}
+          alt={props.name}
+          width={props.isBottom ? 152 : 96}
+          height={props.isBottom ? 152 : 96}
+        />
+        <div css={menuName}>{props.name}</div>
+        <div css={menuPrice}>{props.price.toLocaleString("ko-KR")}원</div>
+      </div>
+    </>
+  );
+};
+
+export default Menu;

--- a/src/customer/components/main/Location.tsx
+++ b/src/customer/components/main/Location.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { css } from "@emotion/react";
 
-import ArrowDown from "public/icons/Arrow-Down.svg";
+import ArrowDown from "public/icons/ArrowDown.svg";
 import BottomSheet from "customer/components/common/bottomsheet";
 import Radio from "customer/components/main/Radio";
 import { Texts } from "styles/common";

--- a/src/customer/components/main/Sort.tsx
+++ b/src/customer/components/main/Sort.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { css } from "@emotion/react";
 
-import ArrowDown from "public/icons/Arrow-Down.svg";
+import ArrowDown from "public/icons/ArrowDown.svg";
 import BottomSheet from "customer/components/common/bottomsheet";
 import Radio from "customer/components/main/Radio";
 import { Texts } from "styles/common";

--- a/src/customer/components/store/Menus.tsx
+++ b/src/customer/components/store/Menus.tsx
@@ -1,0 +1,74 @@
+import React, { useState } from "react";
+import { css } from "@emotion/react";
+
+import RightIcon from "public/icons/RightIcon.svg";
+import { Colors, Texts } from "styles/common";
+import StoreSection from "customer/components/store/Section";
+import Menu from "customer/components/Menu";
+import BottomSheet from "customer/components/common/bottomsheet";
+import MenusBottom from "customer/components/store/MenusBottom";
+
+const menuWrapper = css`
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 0.25rem;
+`;
+
+const more = css`
+  ${Texts.B1_13_M1}
+  color: ${Colors.neutral90};
+  display: flex;
+  justify-content: end;
+  align-items: center;
+  cursor: pointer;
+`;
+
+const Menus = () => {
+  const [open, setOpen] = useState(false);
+
+  const menuArr = [
+    { id: 1, name: "메밀막국수", price: 8500, img: "/images/dummy/pizza.png" },
+    { id: 2, name: "메밀막국수", price: 850000, img: "/images/dummy/pizza.png" },
+    { id: 3, name: "메밀막국수", price: 8500, img: "/images/dummy/pizza.png" },
+    { id: 4, name: "메밀막국수", price: 8500, img: "/images/dummy/pizza.png" },
+    { id: 5, name: "메밀막국수", price: 8500, img: "/images/dummy/pizza.png" },
+    { id: 6, name: "메밀막국수", price: 8500, img: "/images/dummy/pizza.png" },
+    { id: 7, name: "메밀막국수", price: 8500, img: "/images/dummy/pizza.png" },
+    { id: 8, name: "메밀막국수", price: 8500, img: "/images/dummy/pizza.png" },
+  ];
+
+  return (
+    <>
+      <StoreSection sectionTitle="메뉴" menuCount={menuArr.length} fold={true}>
+        <div css={menuWrapper}>
+          {menuArr
+            .filter((_, idx) => idx < 3)
+            .map((menu) => (
+              <Menu
+                key={menu.id}
+                imgSrc={menu.img}
+                name={menu.name}
+                price={menu.price}
+                isBottom={false}
+              />
+            ))}
+        </div>
+        <div css={more} onClick={() => setOpen(true)}>
+          더보기
+          <RightIcon width={14} height={14} stroke={Colors.neutral90} />
+        </div>
+      </StoreSection>
+      <BottomSheet
+        height="40.125rem"
+        isBackButton={true}
+        isXButton={false}
+        open={open}
+        setOpen={setOpen}
+        title="메뉴"
+        component={<MenusBottom menus={menuArr} />}
+      />
+    </>
+  );
+};
+
+export default Menus;

--- a/src/customer/components/store/MenusBottom.tsx
+++ b/src/customer/components/store/MenusBottom.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { css } from "@emotion/react";
+
+import Menu from "customer/components/Menu";
+
+type MenusBottomProps = {
+  menus: { id: number; name: string; price: number; img: string }[];
+};
+
+const wrapper = css`
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  padding: 2rem 1.25rem;
+  gap: 1rem;
+  overflow: scroll;
+  height: 36.875rem;
+`;
+
+const MenusBottom = (props: MenusBottomProps) => {
+  return (
+    <>
+      <div css={wrapper}>
+        {props.menus.map((menu) => (
+          <Menu
+            key={menu.id}
+            imgSrc={menu.img}
+            name={menu.name}
+            price={menu.price}
+            isBottom={true}
+          />
+        ))}
+      </div>
+    </>
+  );
+};
+
+export default MenusBottom;

--- a/src/customer/components/store/Section.tsx
+++ b/src/customer/components/store/Section.tsx
@@ -1,28 +1,69 @@
-import React, { ReactNode } from "react";
+import React, { ReactNode, useState } from "react";
 import { css } from "@emotion/react";
 
-import { Texts } from "styles/common";
+import { Colors, Texts } from "styles/common";
+import ArrowUp from "public/icons/ArrowUp.svg";
+import ArrowDown from "public/icons/ArrowDown.svg";
 
 type StoreSectionProps = {
   children: ReactNode;
   sectionTitle: string;
+  menuCount?: number;
+  fold: boolean;
 };
 
 const wrapper = css`
   padding: 1.5rem 1.25rem 0 1.25rem;
 `;
 
-const title = css`
+const headerWrapper = css`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   margin-bottom: 0.75rem;
+`;
+
+const titleWrapper = css`
+  display: flex;
+  gap: 0.25rem;
+`;
+
+const title = css`
   ${Texts.S1_16_B}
 `;
 
-const StoreSection = ({ children, sectionTitle }: StoreSectionProps) => {
+const count = css`
+  ${Texts.S1_16_B}
+  color: ${Colors.amber50};
+`;
+
+const arrow = css`
+  height: 1.5rem;
+  cursor: pointer;
+`;
+
+const StoreSection = ({ children, sectionTitle, menuCount, fold }: StoreSectionProps) => {
+  const [open, setOpen] = useState(true);
+
   return (
     <>
       <div css={wrapper}>
-        <div css={title}>{sectionTitle}</div>
-        {children}
+        <div css={headerWrapper}>
+          <div css={titleWrapper}>
+            <div css={title}>{sectionTitle}</div>
+            <div css={count}>{menuCount}</div>
+          </div>
+          {fold && (
+            <div css={arrow} onClick={() => setOpen((prev) => !prev)}>
+              {open ? (
+                <ArrowUp width={24} height={24} stroke={Colors.neutral70} />
+              ) : (
+                <ArrowDown width={24} height={24} stroke={Colors.neutral70} />
+              )}
+            </div>
+          )}
+        </div>
+        {open && children}
       </div>
     </>
   );

--- a/src/customer/components/store/Subs.tsx
+++ b/src/customer/components/store/Subs.tsx
@@ -44,7 +44,7 @@ const Subs = (props: SubsProps) => {
 
   return (
     <>
-      <StoreSection sectionTitle="구독권">
+      <StoreSection sectionTitle="구독권" fold={false}>
         <div css={subsWrapper}>
           {subsArr.map((el) => (
             <StoreCoupon


### PR DESCRIPTION
## 수정
- 가게 상세페이지 메뉴 섹션 추가
  - 바텀시트 사용하여 더보기 추가
- section 컴포넌트 헤더 수정
  - 카운트, fold 기능 추가
- arrow-down 파일 이름을 ArrowDown으로 수정

## 참고
- 노션 태스크: https://www.notion.so/8348964c3db740e388a5527bd26faf50?pvs=4