### PR TITLE
바텀시트 애니메이션 수정

### DIFF
--- a/src/customer/components/common/bottomsheet/index.tsx
+++ b/src/customer/components/common/bottomsheet/index.tsx
@@ -18,34 +18,31 @@ type BottomSheetProps = {
 const fadeIn = keyframes`
   from {
     opacity: 0;
-    z-index: 0;
   }
 
   to {
     opacity: 0.6;
-    z-index: 2;
   }
 `;
 
 const fadeOut = keyframes`
   from {
     opacity: 0.6;
-    z-index: 2;
   }
   
   to {
     opacity: 0;
-    z-index: 0;
   }
 `;
 
 const outerWrapper = (open: boolean) => css`
-  animation: ${open ? fadeIn : fadeOut} 0.3s ease;
+  animation: ${open ? fadeIn : fadeOut} 0.3s ease-in;
   position: absolute;
   top: 0;
   left: 0;
   width: 100vw;
   height: 100vh;
+  z-index: 2;
 `;
 
 const wrapper = css`
@@ -111,7 +108,7 @@ const BottomSheet = (props: BottomSheetProps) => {
   };
 
   useEffect(() => {
-    !props.open ? setTimeout(() => setIsVisible(false), 300) : setIsVisible(true);
+    !props.open ? setTimeout(() => setIsVisible(false), 290) : setIsVisible(true);
   }, [props.open]);
 
   if (!isVisible) return null;

--- a/styles/globals.tsx
+++ b/styles/globals.tsx
@@ -37,6 +37,8 @@ const global = css`
 
   body {
     margin: 0;
+    overflow-x: hidden;
+    overflow-y: scroll;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
   }


### PR DESCRIPTION
## 수정
- 바텀시트 애니메이션 수정
  - isVisible의 값을 바꾸는 setTimeout 시간을 기존 0.3s 보다 작게 수정
  - ease 대신 천천히 시작하여 속도가 줄어들지 않는 ease-in 사용
  - z-index 값 고정

## 참고
- 노션 태스크: https://www.notion.so/e2774d359fe84a70bd5362b3d9d3dfe0?pvs=4