### PR TITLE
text input에 onchange 속성 추가

### DIFF
--- a/pages/customer/store/[id]/payment.tsx
+++ b/pages/customer/store/[id]/payment.tsx
@@ -8,12 +8,12 @@ import PaymentMethod from "customer/store/menu/payment/Method";
 import PaymentConsent from "customer/store/menu/payment/Consent";
 import { Colors, Texts } from "styles/common";
 
-export type selectedType = {
+export type SelectedType = {
   id: string;
   name: string;
 };
-export type cashReceiptsType = { isPersonal: boolean; data: string; isUse: boolean };
-export type transferType = {
+export type CashReceiptsType = { isPersonal: boolean; data: string; isUse: boolean };
+export type TransferType = {
   id: string;
   name: string;
   accountHolder: string;
@@ -50,13 +50,13 @@ const buyButton = (isActive: boolean) => css`
 
 const StorePayment = () => {
   const [selectMethod, setSelectMethod] = useState(1);
-  const [cashReceipts, setCashReceipts] = useState<cashReceiptsType>({
+  const [cashReceipts, setCashReceipts] = useState<CashReceiptsType>({
     isPersonal: true,
     data: "",
     isUse: false,
   });
   const [selectedCard, setSelectedCard] = useState({ id: "", name: "" });
-  const [selectedBank, setSelectedBank] = useState<transferType>({
+  const [selectedBank, setSelectedBank] = useState<TransferType>({
     id: "",
     name: "",
     accountHolder: "",

--- a/pages/customer/store/[id]/payment.tsx
+++ b/pages/customer/store/[id]/payment.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { css } from "@emotion/react";
 
 import Layout from "common/layout";
@@ -12,8 +12,13 @@ export type selectedType = {
   id: string;
   name: string;
 };
-
 export type cashReceiptsType = { isPersonal: boolean; data: string; isUse: boolean };
+export type transferType = {
+  id: string;
+  name: string;
+  accountHolder: string;
+  accountNumber: number;
+};
 
 const DUMMY_PAYMENT = {
   storeName: "정갈한솥",
@@ -29,28 +34,59 @@ const couponWrapper = css`
 
 const buttonWrapper = css`
   padding: 0 1.25rem;
+  padding-bottom: 5rem;
 `;
 
-const buyButton = css`
+const buyButton = (isActive: boolean) => css`
   width: 100%;
   border-radius: 0.25rem;
   margin-top: 2rem;
   padding: 0.688rem 0;
-  color: ${Colors.white};
-  background-color: ${Colors.amber50};
+  cursor: ${isActive ? "pointer" : "default"};
+  color: ${isActive ? Colors.white : Colors.neutral50};
+  background-color: ${isActive ? Colors.amber50 : Colors.neutral20};
   ${Texts.S3_18_M}
 `;
 
 const StorePayment = () => {
   const [selectMethod, setSelectMethod] = useState(1);
-  const [cashReceipts, SetCashReceipts] = useState<cashReceiptsType>({
+  const [cashReceipts, setCashReceipts] = useState<cashReceiptsType>({
     isPersonal: true,
     data: "",
     isUse: false,
   });
   const [selectedCard, setSelectedCard] = useState({ id: "", name: "" });
-  const [selectedBank, setSelectedBank] = useState({ id: "", name: "" });
+  const [selectedBank, setSelectedBank] = useState<transferType>({
+    id: "",
+    name: "",
+    accountHolder: "",
+    accountNumber: 0,
+  });
   const [isConsent, setIsConsent] = useState(false);
+
+  useEffect(() => {
+    setSelectedCard({ id: "", name: "" });
+    setSelectedBank({ id: "", name: "", accountHolder: "", accountNumber: 0 });
+    setCashReceipts({ data: "", isPersonal: true, isUse: false });
+  }, [selectMethod]);
+
+  const buttonActive = (): boolean => {
+    const completeCashReceipts = cashReceipts.isUse ? cashReceipts.data : true;
+    switch (selectMethod) {
+      case 1:
+        return Boolean(selectedCard.id) && isConsent;
+      case 2:
+        return (
+          Boolean(selectedBank.id) &&
+          Boolean(selectedBank.accountHolder) &&
+          Boolean(selectedBank.accountNumber) &&
+          Boolean(completeCashReceipts) &&
+          isConsent
+        );
+      default:
+        return isConsent;
+    }
+  };
 
   return (
     <Layout title="결제" subTitle="결제화면">
@@ -70,7 +106,7 @@ const StorePayment = () => {
         selectMethod={selectMethod}
         setSelectMethod={setSelectMethod}
         cashReceipts={cashReceipts}
-        setCashReceipts={SetCashReceipts}
+        setCashReceipts={setCashReceipts}
         selectedCard={selectedCard}
         setSelectedCard={setSelectedCard}
         selectedBank={selectedBank}
@@ -78,7 +114,9 @@ const StorePayment = () => {
       />
       <PaymentConsent isConsent={isConsent} setIsConsent={setIsConsent} />
       <div css={buttonWrapper}>
-        <button css={buyButton}>{DUMMY_PAYMENT.price.toLocaleString("ko-KR")}원 결제하기</button>
+        <button css={buyButton(buttonActive())}>
+          {DUMMY_PAYMENT.price.toLocaleString("ko-KR")}원 결제하기
+        </button>
       </div>
     </Layout>
   );

--- a/src/components/common/input/Section.tsx
+++ b/src/components/common/input/Section.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { Dispatch, SetStateAction } from "react";
 import { css } from "@emotion/react";
 
 import { Colors, Texts } from "styles/common";
@@ -13,6 +13,8 @@ type InputSectionProps = {
   state?: "error" | "success" | "";
   action?: () => void;
   message?: { error?: string; success: string };
+  setState?: Dispatch<SetStateAction<any>> | Dispatch<SetStateAction<string>>;
+  objectKey?: string;
 };
 
 const inputWrapper = css`
@@ -61,6 +63,8 @@ const InputSection = (props: InputSectionProps) => {
             placeholder={props.placeholder}
             state={props.state}
             message={props.message}
+            setState={props.setState}
+            objectKey={props.objectKey}
           />
           <button css={inputBtn(props.state)} onClick={props.action}>
             {props.btn}

--- a/src/components/common/input/Text.tsx
+++ b/src/components/common/input/Text.tsx
@@ -1,10 +1,12 @@
-import React from "react";
+import React, { ChangeEvent, Dispatch, SetStateAction } from "react";
 import { css } from "@emotion/react";
 
 import { Colors, Texts } from "styles/common";
 
 type TextInputProps = {
   width: string;
+  setState?: Dispatch<SetStateAction<any>> | Dispatch<SetStateAction<string>>;
+  objectKey?: string;
   placeholder?: string;
   state?: "error" | "success" | "";
   message?: { error?: string; success: string };
@@ -39,9 +41,25 @@ const success = css`
 `;
 
 const TextInput = (props: TextInputProps) => {
+  const handleInput = (e: ChangeEvent<HTMLInputElement>) => {
+    if (!props.setState) return;
+    if (props.objectKey) {
+      props.setState((prev: any) => {
+        return { ...prev, [props.objectKey as string]: e.target.value };
+      });
+    } else {
+      props.setState(e.target.value);
+    }
+  };
+
   return (
     <div css={wrapper}>
-      <input type="search" css={input(props)} placeholder={props.placeholder} />
+      <input
+        type="search"
+        css={input(props)}
+        placeholder={props.placeholder}
+        onChange={handleInput}
+      />
       {props.state === "error" && <div css={error}>{props.message?.error}</div>}
       {props.state === "success" && <div css={success}>{props.message?.success}</div>}
     </div>

--- a/src/components/customer/login/AddProfile.tsx
+++ b/src/components/customer/login/AddProfile.tsx
@@ -53,9 +53,11 @@ const submit = (isOkay: boolean) => css`
 const AddProfile = () => {
   const [isCheckedConsent, setIsCheckedConsent] = useState(false);
   const [inputState, setInputState] = useState<InpustStateTypes[]>(["", ""]);
+  const [profileData, setProfileData] = useState({ name: "", phone: "" });
 
   const checkValid = () => {
     // TODO: 닉네임 중복확인 api 요청
+    if (!profileData.name) return alert("닉네임을 입력하세요.");
     const randomNum = Math.floor(Math.random() * 2) + 1;
     randomNum === 1
       ? setInputState((prev) => ["success", prev[1]])
@@ -64,6 +66,7 @@ const AddProfile = () => {
 
   const requestAuth = () => {
     // TODO: 인증요청 api 요청
+    if (!profileData.phone) return alert("전화번호를 입력하세요.");
     setInputState((prev) => [prev[0], "success"]);
   };
 
@@ -75,6 +78,7 @@ const AddProfile = () => {
       isRequired: true,
       btnFnc: checkValid,
       message: { success: "사용가능한 닉네임입니다.", error: "중복된 닉네임입니다." },
+      objectKey: "name",
     },
     {
       label: "휴대폰 번호",
@@ -83,6 +87,7 @@ const AddProfile = () => {
       isRequired: true,
       btnFnc: requestAuth,
       message: { success: "인증되었습니다." },
+      objectKey: "phone",
     },
   ];
 
@@ -106,6 +111,8 @@ const AddProfile = () => {
               state={inputState[idx]}
               action={el.btnFnc}
               message={el.message}
+              setState={setProfileData}
+              objectKey={el.objectKey}
             />
           ))}
         </div>

--- a/src/components/customer/my/EditProfile.tsx
+++ b/src/components/customer/my/EditProfile.tsx
@@ -7,6 +7,8 @@ import InputSection from "common/input/Section";
 import Modal from "common/Modal";
 import Dialog from "customer/my/Dialog";
 
+type InpustStateTypes = "error" | "success" | "";
+
 const wrapper = css`
   display: flex;
   flex-direction: column;
@@ -53,18 +55,65 @@ const dialogContent = [
 ];
 const EditProfile = () => {
   const [openModal, setOpenModal] = useState(false);
+  const [inputState, setInputState] = useState<InpustStateTypes[]>(["", ""]);
+  const [profileData, setProfileData] = useState({ name: "", phone: "" });
+
+  const checkValid = () => {
+    // TODO: 닉네임 중복확인 api 요청
+    if (!profileData.name) return alert("닉네임을 입력하세요.");
+    const randomNum = Math.floor(Math.random() * 2) + 1;
+    randomNum === 1
+      ? setInputState((prev) => ["success", prev[1]])
+      : setInputState((prev) => ["error", prev[1]]);
+  };
+
+  const requestAuth = () => {
+    // TODO: 인증요청 api 요청
+    if (!profileData.phone) return alert("전화번호를 입력하세요.");
+    setInputState((prev) => [prev[0], "success"]);
+  };
+
+  const inputArr = [
+    {
+      label: "닉네임",
+      placeholder: "닉네임 입력",
+      btn: "중복확인",
+      isRequired: false,
+      btnFnc: checkValid,
+      message: { success: "사용가능한 닉네임입니다.", error: "중복된 닉네임입니다." },
+      objectKey: "name",
+    },
+    {
+      label: "휴대폰 번호",
+      placeholder: "휴대폰 번호 입력('-'제외)",
+      btn: "인증요청",
+      isRequired: false,
+      btnFnc: requestAuth,
+      message: { success: "인증되었습니다." },
+      objectKey: "phone",
+    },
+  ];
+
   return (
     <>
       <div css={wrapper}>
         <Avatar />
         <div css={inputList}>
-          <InputSection label="닉네임" placeholder="닉네임 입력" btn="중복확인" isBottom={true} />
-          <InputSection
-            label="휴대폰 번호"
-            placeholder="휴대폰 번호 입력('-'제외)"
-            btn="다시 본인인증"
-            isBottom={true}
-          />
+          {inputArr.map((el, idx) => (
+            <InputSection
+              label={el.label}
+              placeholder={el.placeholder}
+              btn={el.btn}
+              isBottom={true}
+              key={el.label}
+              isRequired={el.isRequired}
+              state={inputState[idx]}
+              action={el.btnFnc}
+              message={el.message}
+              setState={setProfileData}
+              objectKey={el.objectKey}
+            />
+          ))}
         </div>
         <div css={btnWrapper}>
           <button

--- a/src/components/customer/store/menu/payment/CashReceipts.tsx
+++ b/src/components/customer/store/menu/payment/CashReceipts.tsx
@@ -1,14 +1,14 @@
 import React, { Dispatch, SetStateAction } from "react";
 import { css } from "@emotion/react";
 
-import { cashReceiptsType } from "pages/customer/store/[id]/payment";
+import { CashReceiptsType } from "pages/customer/store/[id]/payment";
 import Checkbox from "common/input/Checkbox";
 import TextInput from "common/input/Text";
 import { Texts } from "styles/common";
 
-type CashReceiptsType = {
-  cashReceipts: cashReceiptsType;
-  setCashReceipts: Dispatch<SetStateAction<cashReceiptsType>>;
+type CashReceiptsProps = {
+  cashReceipts: CashReceiptsType;
+  setCashReceipts: Dispatch<SetStateAction<CashReceiptsType>>;
 };
 
 const receiptLabel = css`
@@ -57,7 +57,7 @@ const inputWrapper = css`
   margin-bottom: 1.25rem;
 `;
 
-const CashReceipts = (props: CashReceiptsType) => {
+const CashReceipts = (props: CashReceiptsProps) => {
   const eraseData = () => {
     if (!props.cashReceipts.isUse)
       return props.setCashReceipts((prev) => {

--- a/src/components/customer/store/menu/payment/CashReceipts.tsx
+++ b/src/components/customer/store/menu/payment/CashReceipts.tsx
@@ -58,10 +58,17 @@ const inputWrapper = css`
 `;
 
 const CashReceipts = (props: CashReceiptsType) => {
+  const eraseData = () => {
+    if (!props.cashReceipts.isUse)
+      return props.setCashReceipts((prev) => {
+        return { ...prev, data: "" };
+      });
+  };
+
   return (
     <>
       <div css={receiptLabel}>
-        <Checkbox setIsChecked={props.setCashReceipts} objectKey="isUse" />
+        <Checkbox setIsChecked={props.setCashReceipts} objectKey="isUse" extraFnc={eraseData} />
         <label>현금 영수증 발행</label>
       </div>
       {props.cashReceipts?.isUse && (
@@ -102,7 +109,7 @@ const CashReceipts = (props: CashReceiptsType) => {
               {props.cashReceipts.isPersonal ? "휴대폰 번호" : "사업자 번호"}
             </label>
             {/* TODO: input입력 시 cashReceipts.data에 값 입력 */}
-            <TextInput width="100%" />
+            <TextInput width="100%" setState={props.setCashReceipts} objectKey="data" />
           </div>
         </>
       )}

--- a/src/components/customer/store/menu/payment/Method.tsx
+++ b/src/components/customer/store/menu/payment/Method.tsx
@@ -1,7 +1,7 @@
 import React, { Dispatch, SetStateAction } from "react";
 import { css } from "@emotion/react";
 
-import { cashReceiptsType, selectedType, transferType } from "pages/customer/store/[id]/payment";
+import { CashReceiptsType, SelectedType, TransferType } from "pages/customer/store/[id]/payment";
 import StoreSection from "customer/store/Section";
 import MethodButtonList from "customer/store/menu/payment/MethodButtonList";
 import PaymentSelect from "customer/store/menu/payment/Select";
@@ -20,12 +20,12 @@ const PAYMENT_METHODS = [
 type PaymentMethodProps = {
   selectMethod: number;
   setSelectMethod: Dispatch<SetStateAction<number>>;
-  cashReceipts: cashReceiptsType;
-  setCashReceipts: Dispatch<SetStateAction<cashReceiptsType>>;
-  selectedCard: selectedType;
-  setSelectedCard: Dispatch<SetStateAction<selectedType>>;
-  selectedBank: transferType;
-  setSelectedBank: Dispatch<SetStateAction<transferType>>;
+  cashReceipts: CashReceiptsType;
+  setCashReceipts: Dispatch<SetStateAction<CashReceiptsType>>;
+  selectedCard: SelectedType;
+  setSelectedCard: Dispatch<SetStateAction<SelectedType>>;
+  selectedBank: TransferType;
+  setSelectedBank: Dispatch<SetStateAction<TransferType>>;
 };
 
 const methodButtonList = css`

--- a/src/components/customer/store/menu/payment/Method.tsx
+++ b/src/components/customer/store/menu/payment/Method.tsx
@@ -1,7 +1,7 @@
 import React, { Dispatch, SetStateAction } from "react";
 import { css } from "@emotion/react";
 
-import { cashReceiptsType, selectedType } from "pages/customer/store/[id]/payment";
+import { cashReceiptsType, selectedType, transferType } from "pages/customer/store/[id]/payment";
 import StoreSection from "customer/store/Section";
 import MethodButtonList from "customer/store/menu/payment/MethodButtonList";
 import PaymentSelect from "customer/store/menu/payment/Select";
@@ -24,8 +24,8 @@ type PaymentMethodProps = {
   setCashReceipts: Dispatch<SetStateAction<cashReceiptsType>>;
   selectedCard: selectedType;
   setSelectedCard: Dispatch<SetStateAction<selectedType>>;
-  selectedBank: selectedType;
-  setSelectedBank: Dispatch<SetStateAction<selectedType>>;
+  selectedBank: transferType;
+  setSelectedBank: Dispatch<SetStateAction<transferType>>;
 };
 
 const methodButtonList = css`
@@ -85,11 +85,11 @@ const PaymentMethod = (props: PaymentMethodProps) => {
           </div>
           <div css={inputWrapper}>
             <label css={label}>예금주명</label>
-            <TextInput width="100%" />
+            <TextInput width="100%" setState={props.setSelectedBank} objectKey="accountHolder" />
           </div>
           <div css={inputWrapper}>
             <label css={label}>계좌번호</label>
-            <TextInput width="100%" />
+            <TextInput width="100%" setState={props.setSelectedBank} objectKey="accountNumber" />
           </div>
         </>
       )}

--- a/src/components/customer/store/menu/payment/Select.tsx
+++ b/src/components/customer/store/menu/payment/Select.tsx
@@ -4,13 +4,13 @@ import { css } from "@emotion/react";
 import { Colors, Texts } from "styles/common";
 import ArrowDown from "public/icons/ArrowDown.svg";
 import ArrowUp from "public/icons/ArrowUp.svg";
-import { selectedType, transferType } from "pages/customer/store/[id]/payment";
+import { SelectedType, TransferType } from "pages/customer/store/[id]/payment";
 
 type PaymentSelectProps = {
   placeholder: string;
-  list: selectedType[] | transferType[];
-  selected: selectedType | transferType;
-  setSelected: Dispatch<SetStateAction<selectedType>> | Dispatch<SetStateAction<transferType>>;
+  list: SelectedType[] | TransferType[];
+  selected: SelectedType | TransferType;
+  setSelected: Dispatch<SetStateAction<SelectedType>> | Dispatch<SetStateAction<TransferType>>;
 };
 
 const wrapper = css`

--- a/src/components/customer/store/menu/payment/Select.tsx
+++ b/src/components/customer/store/menu/payment/Select.tsx
@@ -4,13 +4,13 @@ import { css } from "@emotion/react";
 import { Colors, Texts } from "styles/common";
 import ArrowDown from "public/icons/ArrowDown.svg";
 import ArrowUp from "public/icons/ArrowUp.svg";
-import { selectedType } from "pages/customer/store/[id]/payment";
+import { selectedType, transferType } from "pages/customer/store/[id]/payment";
 
 type PaymentSelectProps = {
   placeholder: string;
-  list: selectedType[];
-  selected: selectedType;
-  setSelected: Dispatch<SetStateAction<selectedType>>;
+  list: selectedType[] | transferType[];
+  selected: selectedType | transferType;
+  setSelected: Dispatch<SetStateAction<selectedType>> | Dispatch<SetStateAction<transferType>>;
 };
 
 const wrapper = css`
@@ -71,7 +71,9 @@ const PaymentSelect = (props: PaymentSelectProps) => {
                 css={option}
                 key={item.id}
                 onClick={() => {
-                  props.setSelected(item);
+                  props.setSelected((prev: any) => {
+                    return { ...prev, ...item };
+                  });
                   setIsOpen(false);
                 }}
               >


### PR DESCRIPTION
## 수정
- text input에 onchange 속성 추가
- 결제화면, 프로필 수정 페이지에 적용
- 유효성 체크하여 submit 버튼 disable 적용

## 참고
- 노션 태스크: https://www.notion.so/text-input-onchange-3ee2ec54e8db49f19255aa42c37154ef?pvs=4