### PR TITLE
결제완료 페이지 구현

### DIFF
--- a/pages/customer/store/[id]/payment/complete.tsx
+++ b/pages/customer/store/[id]/payment/complete.tsx
@@ -47,7 +47,7 @@ const StorePaymentComplete = () => {
   const router = useRouter();
 
   useEffect(() => {
-    if (!router.query?.price) router.push("/customer");
+    if (!router.query?.price) router.back();
   }, []);
 
   if (!router.query?.price) return null;

--- a/pages/customer/store/[id]/payment/complete.tsx
+++ b/pages/customer/store/[id]/payment/complete.tsx
@@ -1,0 +1,78 @@
+import React, { useEffect } from "react";
+import { useRouter } from "next/router";
+import { css } from "@emotion/react";
+
+import Layout from "common/layout";
+import { Colors, Texts } from "styles/common";
+import Check from "public/icons/Check.svg";
+
+const wrapper = css`
+  padding: 14.625rem 0 16.313rem 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+const paymentWrapper = css`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.375rem;
+`;
+
+const title = css`
+  ${Texts.H1_20_B}
+`;
+
+const description = css`
+  ${Texts.B3_15_R2}
+`;
+
+const buttonWrapper = css`
+  margin-top: 6.625rem;
+  width: 100%;
+  padding: 0 1.25rem;
+`;
+
+const submitButton = css`
+  width: 100%;
+  background-color: ${Colors.amber50};
+  border-radius: 0.25rem;
+  height: 3rem;
+  color: ${Colors.white};
+  ${Texts.S3_18_M}
+`;
+
+const StorePaymentComplete = () => {
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!router.query?.price) router.push("/customer");
+  }, []);
+
+  if (!router.query?.price) return null;
+
+  return (
+    <>
+      <Layout title="결제완료" isNoHeader={true}>
+        <div css={wrapper}>
+          <div css={paymentWrapper}>
+            <h1 css={title}>결제완료</h1>
+            <Check width={55} height={55} fill={Colors.green50} />
+            <div css={description}>
+              결제금액 {Number(router.query.price).toLocaleString("ko-KR")}원이 정상적으로
+              처리되었습니다!
+            </div>
+          </div>
+          <div css={buttonWrapper}>
+            <button css={submitButton} onClick={() => router.push("/customer")}>
+              확인
+            </button>
+          </div>
+        </div>
+      </Layout>
+    </>
+  );
+};
+
+export default StorePaymentComplete;

--- a/pages/customer/store/[id]/payment/index.tsx
+++ b/pages/customer/store/[id]/payment/index.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { css } from "@emotion/react";
+import { useRouter } from "next/router";
 
 import Layout from "common/layout";
 import StoreCoupon from "common/coupon/Store";
@@ -49,6 +50,8 @@ const buyButton = (isActive: boolean) => css`
 `;
 
 const StorePayment = () => {
+  const router = useRouter();
+
   const [selectMethod, setSelectMethod] = useState(1);
   const [cashReceipts, setCashReceipts] = useState<CashReceiptsType>({
     isPersonal: true,
@@ -114,7 +117,18 @@ const StorePayment = () => {
       />
       <PaymentConsent isConsent={isConsent} setIsConsent={setIsConsent} />
       <div css={buttonWrapper}>
-        <button css={buyButton(buttonActive())}>
+        <button
+          css={buyButton(buttonActive())}
+          onClick={() =>
+            router.push(
+              {
+                pathname: `${router.asPath}/complete`,
+                query: { price: DUMMY_PAYMENT.price },
+              },
+              `${router.asPath}/complete`
+            )
+          }
+        >
           {DUMMY_PAYMENT.price.toLocaleString("ko-KR")}원 결제하기
         </button>
       </div>

--- a/styles/globals.tsx
+++ b/styles/globals.tsx
@@ -67,7 +67,13 @@ const global = css`
   }
 
   ul,
-  p {
+  p,
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
     padding: 0;
     margin: 0;
   }


### PR DESCRIPTION
## 수정
- 결제완료 페이지 구현
- 이전 결제 페이지에서 가격을 받아와서 보여줌
- 가격이 없이 페이지에 접근 시 customer로 보내버림

## 참고
- 노션 태스크: https://www.notion.so/f83c5c99cbcd4a799679c823dd52cbb5?pvs=4