### PR TITLE
input section의 text input 크기를'100% - 버튼 width'로  적용

### DIFF
--- a/src/components/common/input/Section.tsx
+++ b/src/components/common/input/Section.tsx
@@ -27,6 +27,7 @@ const inputBtnWrapper = css`
   display: flex;
   justify-content: space-between;
   align-items: center;
+  gap: 1rem;
 `;
 
 const inputBtn = (state?: "error" | "success" | "") => css`
@@ -59,7 +60,8 @@ const InputSection = (props: InputSectionProps) => {
         </div>
         <div css={inputBtnWrapper}>
           <TextInput
-            width="12.5rem"
+            width="100%"
+            wrapperWidth="calc(100% - 6.75rem)"
             placeholder={props.placeholder}
             state={props.state}
             message={props.message}

--- a/src/components/common/input/Text.tsx
+++ b/src/components/common/input/Text.tsx
@@ -5,6 +5,7 @@ import { Colors, Texts } from "styles/common";
 
 type TextInputProps = {
   width: string;
+  wrapperWidth?: string;
   setState?: Dispatch<SetStateAction<any>> | Dispatch<SetStateAction<string>>;
   objectKey?: string;
   placeholder?: string;
@@ -12,9 +13,10 @@ type TextInputProps = {
   message?: { error?: string; success: string };
 };
 
-const wrapper = css`
+const wrapper = (width: string) => css`
   display: flex;
   flex-direction: column;
+  width: ${width};
 `;
 
 const input = (props: TextInputProps) => css`
@@ -53,7 +55,7 @@ const TextInput = (props: TextInputProps) => {
   };
 
   return (
-    <div css={wrapper}>
+    <div css={wrapper(props.wrapperWidth ?? "100%")}>
       <input
         type="search"
         css={input(props)}


### PR DESCRIPTION
## 수정
- input section의 text input wrapper 크기 적용
  - `calc(100% - 6.75rem)`으로 적용
  - 이때 6.75rem은 우측 버튼의 너비