### PR TITLE
#136 가게 위치 등록 페이지 구현

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -12,6 +12,14 @@ const nextConfig = {
     });
     return config;
   },
+  async rewrites() {
+    return [
+      {
+        source: "/juso/:path*",
+        destination: "https://business.juso.go.kr/:path*",
+      },
+    ];
+  },
 };
 
 module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "next": "13.2.3",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "react-intersection-observer": "^9.4.3",
     "react-query": "^3.39.3",
     "react-responsive-carousel": "^3.2.23",
     "typescript": "4.9.5",

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -8,10 +8,10 @@ import StoreThumbnailList from "common/storeThumbnail/List";
 import Location from "common/filter/Location";
 import Sort from "common/filter/Sort";
 import Category from "customer/main/Category";
-import SearchBar from "customer/main/SearchBar";
 import CouponSlider from "customer/main/CouponSlider";
 import useLoginStore from "src/store/login";
 import { StoreData } from "pages/api/store";
+import SearchBar from "common/input/Search";
 
 const MOCK_MYCOUPON = [
   {
@@ -90,7 +90,7 @@ const Home = () => {
   return (
     <Layout title="단골손님">
       <div css={searchBar}>
-        <SearchBar />
+        <SearchBar isCustomer placeholder="음식 이름, 구독권 이름 검색" />
       </div>
       {isLogin && <CouponSlider coupons={MOCK_MYCOUPON} />}
       <div css={location}>

--- a/pages/owner/settings/location.tsx
+++ b/pages/owner/settings/location.tsx
@@ -72,6 +72,7 @@ const SettingsLocation = () => {
     const countPerPageNumber = parseInt(countPerPage);
     const totalCountNumber = parseInt(totalCount);
     const currentPageNumber = parseInt(currentPage);
+
     if (
       (totalCountNumber % countPerPageNumber
         ? Math.floor(totalCountNumber / countPerPageNumber) + 1

--- a/pages/owner/settings/location.tsx
+++ b/pages/owner/settings/location.tsx
@@ -7,7 +7,7 @@ import { css } from "@emotion/react";
 import Layout from "common/layout";
 import SearchBar from "common/input/Search";
 import LocationList, { checkedAddrType } from "common/LocationList";
-import Spinner from "common/Spinner";
+import Spinner from "common/spinner";
 import { Colors, Texts } from "styles/common";
 
 const wrapper = css`

--- a/pages/owner/settings/location.tsx
+++ b/pages/owner/settings/location.tsx
@@ -1,0 +1,93 @@
+import React, { useEffect, useState } from "react";
+import { useInfiniteQuery } from "react-query";
+import { useInView } from "react-intersection-observer";
+import axios from "axios";
+import { css } from "@emotion/react";
+
+import Layout from "common/layout";
+import SearchBar from "common/input/Search";
+import LocationList, { checkedAddrType } from "common/LocationList";
+
+const wrapper = css`
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1.5rem 1.25rem;
+`;
+
+const SettingsLocation = () => {
+  const [ref, inView] = useInView();
+  const [query, setQuery] = useState("");
+  const [checkedAddr, setCheckedAddr] = useState<checkedAddrType>({ roadAddr: "", idx: null });
+
+  const { data, refetch, fetchNextPage } = useInfiniteQuery(
+    "location",
+    ({ pageParam = 1 }) =>
+      axios
+        .post(
+          "/juso/addrlink/addrLinkApiJsonp.do",
+          {
+            confmKey: process.env.NEXT_PUBLIC_JUSO_VALIDATION_KEY,
+            keyword: query,
+            resultType: "json",
+            countPerPage: 20,
+            currentPage: pageParam,
+          },
+          { headers: { "content-type": "application/x-www-form-urlencoded" } }
+        )
+        .then((res) => res),
+    {
+      getNextPageParam: (lastPage: any) =>
+        Number(JSON.parse(lastPage.data.slice(1, -1)).results.common.currentPage) + 1,
+    }
+  );
+
+  const locationListData = data && JSON.parse(data?.pages.at(-1)?.data.slice(1, -1)).results;
+
+  useEffect(() => {
+    if (!data) return;
+    const { countPerpage, totalCount, currentpage } = locationListData;
+    /** 계속 fetch되는 것을 막기 위해 현재 페이지가 마지막 페이지라면 return */
+    if (
+      (totalCount % countPerpage ? totalCount / countPerpage + 1 : totalCount / countPerpage) ===
+      currentpage
+    )
+      return;
+    /** 마지막 ref가 보여지면 다음 페이지 fetch */
+    if (inView) fetchNextPage();
+  }, [inView]);
+
+  return (
+    <Layout title="가게 위치 등록" subTitle="위치 등록" isCheckButton={true}>
+      <div css={wrapper}>
+        <SearchBar
+          isCustomer={false}
+          placeholder="언주로 170"
+          setState={setQuery}
+          mutate={refetch}
+        />
+        <div>
+          {locationListData &&
+            data?.pages.map((res: any) => {
+              const locationData = JSON.parse(res.data.slice(1, -1)).results.juso;
+              if (!locationData) return;
+              return locationData.map((el: any, idx: number) => (
+                <LocationList
+                  key={el.roadAddr}
+                  idx={idx}
+                  jibunAddr={el.jibunAddr}
+                  roadAddr={el.roadAddr}
+                  checkedAddr={checkedAddr}
+                  setCheckedAddr={setCheckedAddr}
+                  lastRef={ref}
+                  dataLength={locationData.length}
+                />
+              ));
+            })}
+        </div>
+      </div>
+    </Layout>
+  );
+};
+
+export default SettingsLocation;

--- a/pages/owner/settings/location.tsx
+++ b/pages/owner/settings/location.tsx
@@ -33,7 +33,7 @@ const SettingsLocation = () => {
   const [isSearching, setIsSearching] = useState(false);
   const [checkedAddr, setCheckedAddr] = useState<checkedAddrType>({ roadAddr: "" });
 
-  const { data, isLoading, refetch, fetchNextPage } = useInfiniteQuery(
+  const { data, isFetching, refetch, fetchNextPage } = useInfiniteQuery(
     "location",
     ({ pageParam = 1 }) =>
       axios
@@ -82,13 +82,13 @@ const SettingsLocation = () => {
           setIsSearching={setIsSearching}
         />
         <div>
-          {isLoading ? (
+          {isFetching ? (
             <div css={centerDiv}>
               <Spinner />
             </div>
           ) : (
             locationListData &&
-            (locationListData.juso ? (
+            (locationListData.juso?.length ? (
               data?.pages.map((res: any) => {
                 const locationData = JSON.parse(res.data.slice(1, -1)).results.juso;
                 if (!locationData) return;

--- a/src/components/common/LocationList.tsx
+++ b/src/components/common/LocationList.tsx
@@ -1,0 +1,84 @@
+import React, { Dispatch, SetStateAction } from "react";
+import { css } from "@emotion/react";
+
+import { Colors, Texts } from "styles/common";
+import CheckedRadio from "public/icons/check/CheckedRadio.svg";
+import UnCheckedRadio from "public/icons/check/UnCheckedRadio.svg";
+
+export type checkedAddrType = { roadAddr: string; idx: number | null };
+
+type LocationListProps = {
+  idx: number;
+  roadAddr: string;
+  jibunAddr: string;
+  checkedAddr: checkedAddrType;
+  setCheckedAddr: Dispatch<SetStateAction<checkedAddrType>>;
+  lastRef: (node?: Element | null | undefined) => void;
+  dataLength: number;
+};
+
+const wrapper = css`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.75rem 0;
+  border-bottom: 1px solid #d9d9d9;
+`;
+
+const addrWrapper = css`
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  ${Texts.B2_14_R2}
+`;
+
+const roadArr = css`
+  color: #1a1a1a;
+`;
+
+const jibunWrapper = css`
+  display: flex;
+  gap: 0.438rem;
+`;
+
+const jibunTag = css`
+  display: flex;
+  align-items: center;
+  padding: 0px 0.375rem;
+  border-radius: 7.5rem;
+  background-color: ${Colors.amber50};
+  color: white;
+  ${Texts.C1_11_B}
+`;
+
+const jibunAddr = css`
+  color: #464646;
+`;
+
+const radioButton = css`
+  height: fit-content;
+  background-color: transparent;
+`;
+
+const LocationList = (props: LocationListProps) => {
+  const handleRadio = () => {
+    props.setCheckedAddr({ roadAddr: props.roadAddr, idx: props.idx });
+  };
+
+  return (
+    <div css={wrapper} ref={props.idx === props.dataLength - 1 ? props.lastRef : null}>
+      <div css={addrWrapper}>
+        <div css={roadArr}>{props.roadAddr}</div>
+        <div css={jibunWrapper}>
+          <span css={jibunTag}>지번</span>
+          <span css={jibunAddr}>{props.jibunAddr}</span>
+        </div>
+      </div>
+      <button css={radioButton} onClick={handleRadio}>
+        {props.idx === props.checkedAddr.idx ? <CheckedRadio /> : <UnCheckedRadio />}
+      </button>
+    </div>
+  );
+};
+
+export default LocationList;

--- a/src/components/common/LocationList.tsx
+++ b/src/components/common/LocationList.tsx
@@ -5,7 +5,7 @@ import { Colors, Texts } from "styles/common";
 import CheckedRadio from "public/icons/check/CheckedRadio.svg";
 import UnCheckedRadio from "public/icons/check/UnCheckedRadio.svg";
 
-export type checkedAddrType = { roadAddr: string; idx: number | null };
+export type checkedAddrType = { roadAddr: string };
 
 type LocationListProps = {
   idx: number;
@@ -39,6 +39,7 @@ const roadArr = css`
 const jibunWrapper = css`
   display: flex;
   gap: 0.438rem;
+  align-items: center;
 `;
 
 const jibunTag = css`
@@ -48,6 +49,8 @@ const jibunTag = css`
   border-radius: 7.5rem;
   background-color: ${Colors.amber50};
   color: white;
+  white-space: nowrap;
+  height: fit-content;
   ${Texts.C1_11_B}
 `;
 
@@ -62,7 +65,7 @@ const radioButton = css`
 
 const LocationList = (props: LocationListProps) => {
   const handleRadio = () => {
-    props.setCheckedAddr({ roadAddr: props.roadAddr, idx: props.idx });
+    props.setCheckedAddr({ roadAddr: props.roadAddr });
   };
 
   return (
@@ -75,7 +78,7 @@ const LocationList = (props: LocationListProps) => {
         </div>
       </div>
       <button css={radioButton} onClick={handleRadio}>
-        {props.idx === props.checkedAddr.idx ? <CheckedRadio /> : <UnCheckedRadio />}
+        {props.roadAddr === props.checkedAddr.roadAddr ? <CheckedRadio /> : <UnCheckedRadio />}
       </button>
     </div>
   );

--- a/src/components/common/input/Search.tsx
+++ b/src/components/common/input/Search.tsx
@@ -9,7 +9,7 @@ type SearchBarProps = {
   isCustomer: boolean;
   placeholder: string;
   setState?: Dispatch<SetStateAction<string>>;
-  mutate: any;
+  mutate?: any;
 };
 
 const inputWrapper = css`

--- a/src/components/common/input/Search.tsx
+++ b/src/components/common/input/Search.tsx
@@ -1,4 +1,5 @@
 import React, { ChangeEvent, Dispatch, KeyboardEvent, SetStateAction, useRef } from "react";
+import { useQueryClient } from "react-query";
 import { useRouter } from "next/router";
 import { css } from "@emotion/react";
 
@@ -43,6 +44,7 @@ const searchIcon = css`
 const SearchBar = (props: SearchBarProps) => {
   const inputRef = useRef<HTMLInputElement>(null);
   const router = useRouter();
+  const queryClient = useQueryClient();
 
   const goToSearch = () => {
     router.push("/search");
@@ -56,6 +58,7 @@ const SearchBar = (props: SearchBarProps) => {
   const onKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
     const target = e.target as HTMLInputElement;
     if (e.key === "Enter" && target.value != "") {
+      queryClient.removeQueries("location");
       props.setIsSearching && props.setIsSearching(true);
       props
         .mutate()
@@ -68,6 +71,7 @@ const SearchBar = (props: SearchBarProps) => {
   const onClickSearch = () => {
     const input = inputRef.current as HTMLInputElement;
     if (input.value !== "") {
+      queryClient.removeQueries("location");
       props.setIsSearching && props.setIsSearching(true);
       props
         .mutate()

--- a/src/components/common/input/Search.tsx
+++ b/src/components/common/input/Search.tsx
@@ -10,6 +10,7 @@ type SearchBarProps = {
   placeholder: string;
   setState?: Dispatch<SetStateAction<string>>;
   mutate?: any;
+  setIsSearching?: Dispatch<SetStateAction<boolean>>;
 };
 
 const inputWrapper = css`
@@ -53,6 +54,7 @@ const SearchBar = (props: SearchBarProps) => {
   const onKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
     const target = e.target as HTMLInputElement;
     if (e.key === "Enter" && target.value != "") {
+      props.setIsSearching && props.setIsSearching(true);
       props.mutate();
     }
   };
@@ -60,6 +62,7 @@ const SearchBar = (props: SearchBarProps) => {
   const onClickSearch = () => {
     const input = inputRef.current as HTMLInputElement;
     if (input.value !== "") {
+      props.setIsSearching && props.setIsSearching(true);
       props.mutate();
     }
   };

--- a/src/components/common/input/Search.tsx
+++ b/src/components/common/input/Search.tsx
@@ -11,6 +11,8 @@ type SearchBarProps = {
   setState?: Dispatch<SetStateAction<string>>;
   mutate?: any;
   setIsSearching?: Dispatch<SetStateAction<boolean>>;
+  query?: string;
+  setPreviousQuery?: Dispatch<SetStateAction<string>>;
 };
 
 const inputWrapper = css`
@@ -55,7 +57,11 @@ const SearchBar = (props: SearchBarProps) => {
     const target = e.target as HTMLInputElement;
     if (e.key === "Enter" && target.value != "") {
       props.setIsSearching && props.setIsSearching(true);
-      props.mutate();
+      props
+        .mutate()
+        .then(() => props.setPreviousQuery && props.setPreviousQuery(props.query || ""));
+
+      props.setIsSearching && props.setIsSearching(false);
     }
   };
 
@@ -63,7 +69,10 @@ const SearchBar = (props: SearchBarProps) => {
     const input = inputRef.current as HTMLInputElement;
     if (input.value !== "") {
       props.setIsSearching && props.setIsSearching(true);
-      props.mutate();
+      props
+        .mutate()
+        .then(() => props.setPreviousQuery && props.setPreviousQuery(props.query || ""));
+      props.setIsSearching && props.setIsSearching(false);
     }
   };
 

--- a/src/components/common/input/Search.tsx
+++ b/src/components/common/input/Search.tsx
@@ -1,0 +1,85 @@
+import React, { ChangeEvent, Dispatch, KeyboardEvent, SetStateAction, useRef } from "react";
+import { useRouter } from "next/router";
+import { css } from "@emotion/react";
+
+import { Colors } from "styles/common";
+import Search from "public/icons/etc/Search.svg";
+
+type SearchBarProps = {
+  isCustomer: boolean;
+  placeholder: string;
+  setState?: Dispatch<SetStateAction<string>>;
+  mutate: any;
+};
+
+const inputWrapper = css`
+  position: relative;
+  width: 100%;
+`;
+
+const input = css`
+  background-color: ${Colors.neutral20};
+  border-radius: 4px;
+  width: 100%;
+  height: 2.5rem;
+  padding: 0.5rem 3.25rem 0.5rem 0.75rem;
+  border: 0;
+
+  &:focus {
+    outline: none;
+  }
+`;
+
+const searchIcon = css`
+  position: absolute;
+  right: 0.75rem;
+  top: 50%;
+  transform: translateY(-50%);
+`;
+
+const SearchBar = (props: SearchBarProps) => {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const router = useRouter();
+
+  const goToSearch = () => {
+    router.push("/search");
+  };
+
+  const handleSearch = (e: ChangeEvent<HTMLInputElement>) => {
+    if (!props.setState) return;
+    props.setState(e.target.value);
+  };
+
+  const onKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    const target = e.target as HTMLInputElement;
+    if (e.key === "Enter" && target.value != "") {
+      props.mutate();
+    }
+  };
+
+  const onClickSearch = () => {
+    const input = inputRef.current as HTMLInputElement;
+    if (input.value !== "") {
+      props.mutate();
+    }
+  };
+
+  return (
+    <div css={inputWrapper}>
+      <input
+        type="search"
+        placeholder={props.placeholder}
+        ref={inputRef}
+        css={input}
+        onChange={handleSearch}
+        onFocus={props.isCustomer ? goToSearch : undefined}
+        onKeyDown={!props.isCustomer ? onKeyDown : undefined}
+      />
+      <button onClick={!props.isCustomer ? onClickSearch : undefined}>
+        <Search css={searchIcon} width={24} height={24} stroke={Colors.amber50} />
+      </button>
+    </div>
+  );
+};
+
+export default SearchBar;

--- a/src/components/common/layout/index.tsx
+++ b/src/components/common/layout/index.tsx
@@ -25,6 +25,7 @@ const wrapper = (pathname: string) => css`
   max-width: ${pathname.includes("/owner") ? "768px" : "480px"};
   min-height: calc(100vh - ${BOTTOM_NAV_HEIGHT});
   margin: auto;
+  padding-bottom: ${pathname.includes("/owner") ? BOTTOM_NAV_HEIGHT : "0"};
   box-shadow: rgb(130 130 130 / 15%) 0px ${pathname.includes("/owner") ? "1.25rem" : "0"} 1.25rem;
 `;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5663,6 +5663,11 @@ react-easy-swipe@^0.0.21:
   dependencies:
     prop-types "^15.5.8"
 
+react-intersection-observer@^9.4.3:
+  version "9.4.3"
+  resolved "https://registry.yarnpkg.com/react-intersection-observer/-/react-intersection-observer-9.4.3.tgz#ec84ce0c25cad548075130ea045ac5c7adf908f3"
+  integrity sha512-WNRqMQvKpupr6MzecAQI0Pj0+JQong307knLP4g/nBex7kYfIaZsPpXaIhKHR+oV8z+goUbH9e10j6lGRnTzlQ==
+
 react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"


### PR DESCRIPTION
## 수정
- 가게 위치 등록 페이지 구현
  - 주소기반산업지원서비스의 검색 api 활용
  - react-intersection-observer, useInfiniteQuery 사용하여 무한 스크롤 구현

## 참고
- 노션 태스크: https://www.notion.so/afa3c1c97931416fad30184713910cea?pvs=4