### PR TITLE
유저 정보 및 탈퇴 api 연결

### DIFF
--- a/pages/api/user.ts
+++ b/pages/api/user.ts
@@ -1,10 +1,10 @@
 import axios from "axios";
 
 type UserDataType = {
-  nickname: string;
-  phoneNumber: string;
-  birth: string;
-  multipartFile: File;
+  nickname?: string;
+  phoneNumber?: string;
+  birth?: string;
+  multipartFile?: File;
 };
 
 export const getUserInfo = async () => {
@@ -32,11 +32,26 @@ export const validateUserToken = async () => {
   return response.status;
 };
 
+export const getIsValidName = async (nickname: string) => {
+  const queryKey = `/api/v1/customer/validate/${nickname}`;
+  const response = await axios.get(queryKey);
+  return response.data;
+};
+
 export const deleteUser = async () => {
   const accessToken = localStorage.getItem("userAccessToken");
   const queryKey = "/api/v1/customer";
   const response = await axios.delete(queryKey, {
     headers: { Authorization: `Bearer ${accessToken}` },
+  });
+  return response.data;
+};
+
+export const updateUser = async (userData: UserDataType) => {
+  const accessToken = localStorage.getItem("userAccessToken");
+  const queryKey = "/api/v1/customer/info/update";
+  const response = await axios.post(queryKey, userData, {
+    headers: { Authorization: `Bearer ${accessToken}`, "Content-Type": "multipart/form-data" },
   });
   return response.data;
 };

--- a/pages/api/user.ts
+++ b/pages/api/user.ts
@@ -7,7 +7,8 @@ type UserDataType = {
   multipartFile: File;
 };
 
-export const getUser = async (accessToken: string) => {
+export const getUserInfo = async () => {
+  const accessToken = localStorage.getItem("userAccessToken");
   const queryKey = "/api/v1/customer";
   const response = await axios.get(queryKey, {
     headers: { Authorization: `Bearer ${accessToken}` },
@@ -29,4 +30,13 @@ export const validateUserToken = async () => {
   const accessToken = localStorage.getItem("userAccessToken");
   const response = await axios.post(queryKey, { accessToken });
   return response.status;
+};
+
+export const deleteUser = async () => {
+  const accessToken = localStorage.getItem("userAccessToken");
+  const queryKey = "/api/v1/customer";
+  const response = await axios.delete(queryKey, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+  return response.data;
 };

--- a/pages/login/profile.tsx
+++ b/pages/login/profile.tsx
@@ -5,13 +5,13 @@ import { useQuery } from "react-query";
 import Layout from "common/layout";
 import AddProfile from "customer/login/addProfile";
 import useLoginStore from "src/store/userLogin";
-import { getUser } from "pages/api/user";
+import { getUserInfo } from "pages/api/user";
 
 const Profile = () => {
   const { login } = useLoginStore();
   const { push, query } = useRouter();
 
-  const { data, isFetching } = useQuery("customer", () => getUser(String(query.token)), {
+  const { data, isFetching } = useQuery("customer", getUserInfo, {
     enabled: Boolean(query.token),
   });
 

--- a/pages/login/profile.tsx
+++ b/pages/login/profile.tsx
@@ -13,6 +13,7 @@ const Profile = () => {
 
   const { data, isFetching } = useQuery("customer", getUserInfo, {
     enabled: Boolean(query.token),
+    refetchOnWindowFocus: false,
   });
 
   useEffect(() => {

--- a/src/components/customer/my/editProfile.tsx
+++ b/src/components/customer/my/editProfile.tsx
@@ -61,7 +61,7 @@ const submit = css`
   padding: 0.688rem 0;
   background-color: ${Colors.amber50};
   border-radius: 0.25rem;
-  cursor: ${"pointer"};
+  cursor: pointer;
   color: ${Colors.white};
   ${Texts.S3_18_M}
 `;

--- a/src/components/customer/my/editProfile.tsx
+++ b/src/components/customer/my/editProfile.tsx
@@ -71,10 +71,8 @@ const EditProfile = () => {
   const { logout } = useLoginStore();
 
   const { data, isFetching } = useQuery("userInf", getUserInfo, { refetchOnWindowFocus: false });
-  const { mutateAsync: checkValidName } = useMutation(
-    "validName",
-    () => getIsValidName(profileData.name),
-    {}
+  const { mutateAsync: checkValidName } = useMutation("validName", () =>
+    getIsValidName(profileData.name)
   );
   const { mutateAsync } = useMutation(deleteUser);
   const { mutateAsync: updateUserMutate } = useMutation(updateUser);
@@ -104,6 +102,8 @@ const EditProfile = () => {
 
   const updateInfo = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+    if (profileData.name !== data?.nickname && inputStatus[0] !== "success")
+      return alert("닉네임 중복확인을 해주세요.");
     if (inputStatus[0] === "error") return alert("사용가능한 닉네임을 입력해주세요.");
     updateUserMutate({
       nickname: profileData.name,
@@ -146,6 +146,10 @@ const EditProfile = () => {
   }, [profileData]);
 
   useEffect(() => {
+    setInputStatus((prev) => ["", prev[1]]);
+  }, [profileData.name]);
+
+  useEffect(() => {
     if (!data) return;
     setProfileData({
       name: data.nickname,
@@ -185,8 +189,8 @@ const EditProfile = () => {
         </div>
         <button
           type="submit"
-          css={submit(inputStatus[0] === "success")}
-          disabled={inputStatus[0] !== "success"}
+          css={submit(profileData.name !== data?.nickname ? inputStatus[0] === "success" : true)}
+          disabled={!(profileData.name !== data?.nickname ? inputStatus[0] === "success" : true)}
         >
           저장
         </button>

--- a/src/components/customer/my/editProfile.tsx
+++ b/src/components/customer/my/editProfile.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { FormEvent, useEffect, useState } from "react";
 import { css } from "@emotion/react";
 import { useRouter } from "next/router";
 import { useMutation, useQuery } from "react-query";
@@ -11,7 +11,7 @@ import { InputStatus } from "common/input/text";
 import Spinner from "common/spinner";
 import Dialog from "customer/my/dialog";
 import useLoginStore from "src/store/userLogin";
-import { deleteUser, getUserInfo } from "pages/api/user";
+import { deleteUser, getIsValidName, getUserInfo, updateUser } from "pages/api/user";
 
 const wrapper = css`
   display: flex;
@@ -56,47 +56,63 @@ const inputList = css`
   padding-bottom: 0.75rem;
 `;
 
+const submit = css`
+  width: 100%;
+  padding: 0.688rem 0;
+  background-color: ${Colors.amber50};
+  border-radius: 0.25rem;
+  cursor: ${"pointer"};
+  color: ${Colors.white};
+  ${Texts.S3_18_M}
+`;
+
 const EditProfile = () => {
-  const { push } = useRouter();
+  const { push, reload } = useRouter();
   const { logout } = useLoginStore();
 
-  const { data, isFetching } = useQuery("userInf", getUserInfo);
+  const { data, isFetching } = useQuery("userInf", getUserInfo, { refetchOnWindowFocus: false });
+  const { refetch } = useQuery("validName", () => getIsValidName(profileData.name), {
+    enabled: false,
+    refetchOnWindowFocus: false,
+  });
   const { mutateAsync } = useMutation(deleteUser);
+  const { mutateAsync: updateUserMutate } = useMutation(updateUser);
 
   const [openModal, setOpenModal] = useState(false);
   const [inputStatus, setInputStatus] = useState<InputStatus[]>(["", ""]);
-  const [profileData, setProfileData] = useState({ name: "", phone: "", phoneAuth: "" });
+  const [profileData, setProfileData] = useState({
+    name: "",
+    phone: "",
+    phoneAuth: "",
+    imageUrl: "",
+  });
   const [inputArr, setInputArr] = useState<InputWithButtonType[]>([]);
-  // TODO: 이미지 정보 저장
-  const [, setImage] = useState<File>();
+  const [image, setImage] = useState<File>();
 
   const checkValid = () => {
-    // TODO: 닉네임 중복확인 api 요청
     if (!profileData.name) return alert("닉네임을 입력하세요.");
-    const randomNum = Math.floor(Math.random() * 2) + 1;
-    randomNum === 1
-      ? setInputStatus((prev) => ["success", prev[1]])
-      : setInputStatus((prev) => ["error", prev[1]]);
+    refetch().then((res) => {
+      if (res.status === "error") {
+        alert((res.error as any).response.data.message);
+        setInputStatus((prev) => ["error", prev[1]]);
+      } else {
+        alert("사용가능한 닉네임입니다.");
+        setInputStatus((prev) => ["success", prev[1]]);
+      }
+    });
   };
 
-  const requestAuth = () => {
-    // TODO: 인증요청 api 요청
-    if (!profileData.phone) return alert("전화번호를 입력하세요.");
-    setInputArr((prev) => [
-      prev[0],
-      { ...prev[1], btnName: "재전송" },
-      { ...prev[2], isHidden: false },
-    ]);
-    setInputStatus((prev) => [prev[0], prev[1], "info"]);
-  };
-
-  const checkAuth = () => {
-    // TODO: 문자인증 api 요청
-    if (!profileData.phoneAuth) return alert("인증번호를 입력하세요.");
-    const randomNum = Math.floor(Math.random() * 2) + 1;
-    randomNum === 1
-      ? setInputStatus((prev) => [prev[0], prev[1], "success"])
-      : setInputStatus((prev) => [prev[0], prev[1], "error"]);
+  const updateInfo = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (inputStatus[0] === "error") return alert("사용가능한 닉네임을 입력해주세요.");
+    updateUserMutate({
+      nickname: profileData.name,
+      phoneNumber: profileData.phone,
+      multipartFile: image,
+    }).then(() => {
+      alert("저장되었습니다.");
+      reload();
+    });
   };
 
   useEffect(() => {
@@ -116,35 +132,17 @@ const EditProfile = () => {
       {
         label: "휴대폰 번호",
         placeholder: "휴대폰 번호 입력('-'제외)",
-        btnName: "인증요청",
         isRequired: false,
-        btnAction: requestAuth,
         objectKey: "phone",
         type: "number",
-      },
-      {
-        btnName: "문자인증",
-        btnAction: checkAuth,
-        inputStatusMessage: {
-          success: "인증되었습니다.",
-          info: "문자로 전송된 숫자를 입력해주세요.",
-          error: "인증번호가 맞지 않습니다.",
-        },
-        objectKey: "phoneAuth",
-        isHidden: true,
-        type: "number",
-        minValue: 6,
-        maxValue: 6,
+        minValue: 11,
+        maxValue: 11,
       },
     ]);
   }, []);
 
   useEffect(() => {
-    setInputArr((prev) => [
-      { ...prev[0], btnAction: checkValid },
-      { ...prev[1], btnAction: requestAuth },
-      { ...prev[2], btnAction: checkAuth },
-    ]);
+    setInputArr((prev) => [{ ...prev[0], btnAction: checkValid }, prev[1]]);
   }, [profileData]);
 
   useEffect(() => {
@@ -153,6 +151,7 @@ const EditProfile = () => {
       name: data.nickname,
       phone: data.phoneNumber,
       phoneAuth: "",
+      imageUrl: "",
     });
   }, [data]);
 
@@ -160,8 +159,8 @@ const EditProfile = () => {
 
   return (
     <>
-      <div css={wrapper}>
-        <Avatar setImage={setImage} />
+      <form onSubmit={updateInfo} css={wrapper}>
+        <Avatar imageUrl={data?.profileImageUrl} setImage={setImage} />
         <div css={inputList}>
           {inputArr.map((el, idx) => (
             <InputWithButton
@@ -184,9 +183,13 @@ const EditProfile = () => {
             />
           ))}
         </div>
+        <button type="submit" css={submit}>
+          저장
+        </button>
         <div css={btnWrapper}>
           <div>
             <button
+              type="button"
               onClick={() => {
                 logout();
                 push("/");
@@ -195,13 +198,15 @@ const EditProfile = () => {
               로그아웃
             </button>
             <span css={btnDivider}>|</span>
-            <button onClick={() => setOpenModal(true)}>회원탈퇴</button>
+            <button type="button" onClick={() => setOpenModal(true)}>
+              회원탈퇴
+            </button>
           </div>
-          <button css={iconInfo} onClick={() => push("/source")}>
+          <button type="button" css={iconInfo} onClick={() => push("/source")}>
             아이콘 디자인 소스 정보
           </button>
         </div>
-      </div>
+      </form>
       <Modal onClose={() => setOpenModal(false)} open={openModal}>
         <Dialog
           content={{

--- a/src/components/customer/my/info.tsx
+++ b/src/components/customer/my/info.tsx
@@ -24,10 +24,10 @@ type StateTypes = {
 
 // FIXME: apple의 경우 img가 흰색이라 imgSrc 변경 필요
 const LOGIN_TYPE: readonly StateTypes[] = [
-  { type: "kakao", socialName: "카카오", imgSrc: "/images/loginMethod/kakao.png" },
-  { type: "google", socialName: "구글", imgSrc: "/images/loginMethod/google.png" },
-  { type: "apple", socialName: "Apple", imgSrc: "/images/loginMethod/appleBlack.png" },
-  { type: "naver", socialName: "네이버", imgSrc: "/images/loginMethod/naver.png" },
+  { type: "KAKAO", socialName: "카카오", imgSrc: "/images/loginMethod/kakao.png" },
+  { type: "GOOGLE", socialName: "구글", imgSrc: "/images/loginMethod/google.png" },
+  { type: "APPLE", socialName: "Apple", imgSrc: "/images/loginMethod/appleBlack.png" },
+  { type: "NAVER", socialName: "네이버", imgSrc: "/images/loginMethod/naver.png" },
 ];
 
 const wrapper = css`
@@ -81,7 +81,7 @@ const Info = ({ user: { nickname, loginInfo, avatar }, openProfile }: InfoProps)
   return (
     <div css={wrapper}>
       <Image
-        src={avatar ?? "/images/profile.png"}
+        src={avatar || "/images/profile.png"}
         alt="avatar"
         css={avatarImg}
         width={72}

--- a/src/components/customer/my/profile.tsx
+++ b/src/components/customer/my/profile.tsx
@@ -1,22 +1,37 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
+import { useRouter } from "next/router";
+import { useQuery } from "react-query";
 
 import BottomSheet from "common/bottomSheet";
+import FullPageSpinner from "common/spinner/fullPage";
 import EditProfile from "customer/my/editProfile";
-import Info, { LoginType } from "customer/my/info";
+import Info from "customer/my/info";
+import { getUserInfo } from "pages/api/user";
 
 const Profile = () => {
   const [isOpen, setIsOpen] = useState(false);
 
-  const user = [
-    {
-      nickname: "물고기1234",
-      loginInfo: "kakao" as LoginType,
-    },
-  ];
+  const { push } = useRouter();
+
+  const { data, isFetching } = useQuery("userInfo", getUserInfo);
+
+  useEffect(() => {
+    if (!data) return;
+    if (!data.providerType) push("/");
+  }, [data]);
+
+  if (isFetching) return <FullPageSpinner />;
 
   return (
     <>
-      <Info user={user[0]} openProfile={() => setIsOpen(true)} />
+      <Info
+        user={{
+          loginInfo: data?.providerType,
+          nickname: data?.nickname,
+          avatar: data?.profileImageUrl,
+        }}
+        openProfile={() => setIsOpen(true)}
+      />
       <BottomSheet
         open={isOpen}
         setOpen={setIsOpen}

--- a/src/components/customer/my/profile.tsx
+++ b/src/components/customer/my/profile.tsx
@@ -13,7 +13,7 @@ const Profile = () => {
 
   const { push } = useRouter();
 
-  const { data, isFetching } = useQuery("userInfo", getUserInfo);
+  const { data, isFetching } = useQuery("userInfo", getUserInfo, { refetchOnWindowFocus: false });
 
   useEffect(() => {
     if (!data) return;


### PR DESCRIPTION
## 수정
- 유저 정보 api 연결
  - /my에 유저 정보 적용
  - bottomsheet에도 유저 정보 저장
- 탈퇴 Api 연결
- 닉네임 중복 확인 api 연결
- 정보 수정 api 연결

## 참고
- 구현 안된 것: 로그인 상태 관리
  - 로그인 상태관리가 되지 않았기에 로그인 안하고 /my에 접속하면 에러 발생. 해당부분은 손님 토큰 검증 api를 통해서 수정할 예정