### PR TITLE
Font display 속성 변경

### DIFF
--- a/styles/globals.tsx
+++ b/styles/globals.tsx
@@ -9,7 +9,7 @@ const global = css`
     src: url("/fonts/pretendard-Regular.subset.woff2") format("woff2"),
       url("/fonts/pretendard-Regular.subset.woff") format("woff");
     font-weight: 400;
-    font-display: auto;
+    font-display: swap;
   }
 
   @font-face {
@@ -17,7 +17,7 @@ const global = css`
     src: url("/fonts/pretendard-Medium.subset.woff2") format("woff2"),
       url("/fonts/pretendard-Medium.subset.woff") format("woff");
     font-weight: 500;
-    font-display: auto;
+    font-display: swap;
   }
 
   @font-face {
@@ -25,14 +25,14 @@ const global = css`
     src: url("/fonts/pretendard-Bold.subset.woff2") format("woff2"),
       url("/fonts/pretendard-Bold.subset.woff") format("woff");
     font-weight: 700;
-    font-display: auto;
+    font-display: swap;
   }
 
   @font-face {
     font-family: "blackHanSans";
     src: url("/fonts/blackHanSans.ttf") format("truetype");
     font-weight: 400;
-    font-display: auto;
+    font-display: swap;
   }
 
   * {


### PR DESCRIPTION
## 수정
<img width="783" alt="image" src="https://github.com/jaemisam-a/dangol-sonnim-frontend/assets/84840032/99de831e-1596-4456-9b3f-034b7aa3f0a2">

* lighthouse 진단 결과 개선위해 font-display 속성을 swap으로 변경하여 폰트 로드 되기 전에는 시스템 폰트를 사용하도록 수정함

