### PR TITLE
메뉴 보여주는 디자인 수정 및 드롭다운 훅 생성

### DIFF
--- a/pages/owner/login/index.tsx
+++ b/pages/owner/login/index.tsx
@@ -54,7 +54,8 @@ const smallButtonWrapper = css`
   align-items: center;
   gap: 0.5rem;
 
-  button {
+  button,
+  a {
     ${Texts.B3_15_R2};
     color: ${Colors.neutral70};
   }
@@ -128,7 +129,7 @@ const OwnerLogin = () => {
           <div css={smallButtonWrapper}>
             <Link href="/owner/signup">회원가입</Link>
             <span>|</span>
-            <Link href="/owner/login/password">비밀번호 찾기</Link>
+            <button onClick={() => alert("관리자에게 문의해주세요.")}>비밀번호 찾기</button>
           </div>
         </div>
       </OwnerLayout>

--- a/src/components/common/layout/header/owner.tsx
+++ b/src/components/common/layout/header/owner.tsx
@@ -70,6 +70,16 @@ const hiddenItem = css`
   height: 1.75rem;
 `;
 
+const buttons = css`
+  display: flex;
+  gap: 0.25rem;
+  color: ${Colors.neutral90};
+`;
+
+const buttonDot = css`
+  ${Texts.B2_14_R1}
+`;
+
 const OwnerHeader = (props: OwnerHeaderProps) => {
   const { pathname, back, push } = useRouter();
 
@@ -101,9 +111,15 @@ const OwnerHeader = (props: OwnerHeaderProps) => {
               </button>
               <span css={pageTitle}>{props.subTitle}</span>
               {pathname === "/owner" ? (
-                <button css={textButton} onClick={onOwnerButtonClick}>
-                  {loginState ? "로그아웃" : "로그인/회원가입"}
-                </button>
+                <div css={buttons}>
+                  <button css={textButton} onClick={() => push("/")}>
+                    손님 페이지
+                  </button>
+                  <span css={buttonDot}>•</span>
+                  <button css={textButton} onClick={onOwnerButtonClick}>
+                    {loginState ? "로그아웃" : "로그인/회원가입"}
+                  </button>
+                </div>
               ) : (
                 <button onClick={() => setOpenNav(true)}>
                   <Hamburger />

--- a/src/components/common/menuCard.tsx
+++ b/src/components/common/menuCard.tsx
@@ -5,6 +5,7 @@ import { css } from "@emotion/react";
 import { Colors, Texts } from "styles/common";
 import Close from "public/icons/close/close.svg";
 import Pencil from "public/icons/etc/pencil.svg";
+import { MENU_SIZE_PX } from "customer/store/menu/menus";
 
 type MenuProps = {
   imgSrc: string;
@@ -50,15 +51,15 @@ const btnOnImg = css`
 const MenuCard = (props: MenuProps) => {
   return (
     <>
-      <div>
+      <div style={{ width: "fit-content" }}>
         <div css={imageWrapper}>
           <Image
             css={menuImage(props.isBottom)}
             // FIXME: 이미지 없는 경우 기본 이미지로 설정. 추후 디자인 나오면 수정
             src={props.imgSrc || "/images/logo/logo.png"}
             alt={props.name}
-            width={props.isBottom ? 152 : 96}
-            height={props.isBottom ? 152 : 96}
+            width={props.isBottom ? 152 : MENU_SIZE_PX}
+            height={props.isBottom ? 152 : MENU_SIZE_PX}
           />
           {props.isEdit && (
             <button css={btnOnImg} onClick={props.editAction}>

--- a/src/components/common/popover.tsx
+++ b/src/components/common/popover.tsx
@@ -7,7 +7,6 @@ export type statusType = "edit" | "delete" | "default";
 
 type PopoverProps = {
   isOpen: boolean;
-  setIsOpen: Dispatch<SetStateAction<boolean>>;
   popoverRef: MutableRefObject<null>;
   style: CSSProperties;
   attributes: any;
@@ -50,23 +49,9 @@ const Popover = (props: PopoverProps) => {
       {...props.attributes}
     >
       {props.label === "메뉴" && (
-        <button
-          onClick={() => {
-            props.setStatus && props.setStatus("edit");
-            props.setIsOpen(false);
-          }}
-        >
-          수정
-        </button>
+        <button onClick={() => props.setStatus && props.setStatus("edit")}>수정</button>
       )}
-      <button
-        onClick={() => {
-          props.setStatus && props.setStatus("delete");
-          props.setIsOpen(false);
-        }}
-      >
-        삭제
-      </button>
+      <button onClick={() => props.setStatus && props.setStatus("delete")}>삭제</button>
       <button onClick={props.btnAction} css={colored}>
         {props.label} 등록
       </button>

--- a/src/components/customer/store/menu/menus.tsx
+++ b/src/components/customer/store/menu/menus.tsx
@@ -12,8 +12,11 @@ type MenusPropsType = {
   menuList: { imageUrl: string; menuId: number; name: string; price: number; storeId: number }[];
 };
 
+export const MENU_SIZE_PX = 96;
+
 const menuWrapper = css`
-  display: flex;
+  display: grid;
+  grid-template-columns: repeat(3, ${MENU_SIZE_PX}px);
   justify-content: space-between;
   margin-bottom: 0.25rem;
 `;

--- a/src/components/owner/settings/section.tsx
+++ b/src/components/owner/settings/section.tsx
@@ -1,10 +1,11 @@
-import React, { Dispatch, ReactNode, SetStateAction, useRef, useState } from "react";
+import React, { Dispatch, ReactNode, SetStateAction, useRef } from "react";
 import { usePopper } from "react-popper";
 import { css } from "@emotion/react";
 
 import Kebab from "public/icons/menu/kebab.svg";
 import { Colors, Texts } from "styles/common";
 import Popover, { statusType } from "common/popover";
+import useDropdown from "src/utils/useDropdown";
 
 type StoreSectionProps = {
   children: ReactNode;
@@ -47,9 +48,10 @@ const registrationButton = css`
 `;
 
 const StoreSection = (props: StoreSectionProps) => {
-  const [openPopover, setOpenPopover] = useState(false);
   const kebabRef = useRef(null);
   const popoverRef = useRef(null);
+
+  const [openPopover, setOpenPopover] = useDropdown(kebabRef);
 
   const { styles, attributes } = usePopper(kebabRef.current, popoverRef.current, {
     placement: "bottom-end",
@@ -78,7 +80,6 @@ const StoreSection = (props: StoreSectionProps) => {
                     btnAction={props.btnAction}
                     label={props.sectionTitle}
                     isOpen={openPopover}
-                    setIsOpen={setOpenPopover}
                     popoverRef={popoverRef}
                     style={styles.popper}
                     attributes={attributes.popper}

--- a/src/utils/useDropdown.ts
+++ b/src/utils/useDropdown.ts
@@ -1,0 +1,34 @@
+/**
+ * 드롭다운을 열고 외부를 클릭해서 닫을 수 있게 만든 훅
+ * ref를 만들어서 드롭다운을 여는 버튼에 넣고
+ * useDropdown 훅을 선언해서 defaultValue에 해당 ref를 넣고 사용
+ */
+
+import { Dispatch, RefObject, SetStateAction, useEffect, useState } from "react";
+
+type useDropdownType = (
+  buttonRef: RefObject<HTMLDivElement>,
+) => [boolean, Dispatch<SetStateAction<boolean>>];
+
+const useDropdown: useDropdownType = (buttonRef) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  useEffect(() => {
+    // FIXME: event의 타입을 어떻게 지정해야할지 찾지 못함. 추후 수정 예정
+    const pageClickEvent = (event: any) => {
+      if (buttonRef.current && !buttonRef.current.contains(event.target)) {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener("click", pageClickEvent);
+
+    return () => {
+      document.removeEventListener("click", pageClickEvent);
+    };
+  }, []);
+
+  return [isOpen, setIsOpen];
+};
+
+export default useDropdown;


### PR DESCRIPTION
## 수정
- 가게 상세페이지의 메뉴에서 grid를 사용하여 디자인대로 나오도록 수정
- 드롭다운 훅 만들어서 가게 설정 페이지에서 사용
- 비밀번호 찾기 페이지 안들어가지도록 설정
- 사장님 페이지에서 손님 페이지 이동할 수 있도록 추가